### PR TITLE
refactor(blog): use slug instead of ID in repository methods

### DIFF
--- a/internal/domain/contract/iblog_repository.go
+++ b/internal/domain/contract/iblog_repository.go
@@ -10,7 +10,7 @@ import (
 // IBlogRepository provides methods for managing blog data in the database.
 type IBlogRepository interface {
 	CreateBlog(ctx context.Context, blog *entity.Blog) error
-	GetBlogByID(ctx context.Context, blogID string) (*entity.Blog, error)
+	GetBlogBySlug(ctx context.Context, slug string) (*entity.Blog, error)
 	GetBlogs(ctx context.Context, filterOptions *BlogFilterOptions) ([]*entity.Blog, int64, error)
 	UpdateBlog(ctx context.Context, blogID string, updates map[string]interface{}) error
 	DeleteBlog(ctx context.Context, blogID string) error
@@ -23,8 +23,8 @@ type IBlogRepository interface {
 	IncrementCommentCount(ctx context.Context, blogID string) error
 	DecrementCommentCount(ctx context.Context, blogID string) error
 	GetBlogCounts(ctx context.Context, blogID string) (viewCount, likeCount, dislikeCount, commentCount int, err error)
-	AddTagsToBlog(ctx context.Context, blogID string, tagIDs []string) error
-	RemoveTagsFromBlog(ctx context.Context, blogID string, tagIDs []string) error
+	AddTagsToBlog(ctx context.Context, blogSlug string, tagIDs []string) error
+	RemoveTagsFromBlog(ctx context.Context, blogSlug string, tagIDs []string) error
 	GetBlogsByTagIDs(ctx context.Context, tagIDs []string, page int, pageSize int) ([]*entity.Blog, int64, error)
 }
 

--- a/internal/domain/entity/blog.go
+++ b/internal/domain/entity/blog.go
@@ -6,21 +6,21 @@ import (
 
 // Blog represents a blog post in the system
 type Blog struct {
-	ID              string     `json:"id" db:"id"`
-	Title           string     `json:"title" db:"title"`
-	Content         string     `json:"content" db:"content"`
-	AuthorID        string     `json:"author_id" db:"author_id"`
-	Slug            string     `json:"slug" db:"slug"`
-	Status          BlogStatus `json:"status" db:"status"`
-	CreatedAt       time.Time  `json:"created_at" db:"created_at"`
-	UpdatedAt       time.Time  `json:"updated_at" db:"updated_at"`
-	PublishedAt     *time.Time `json:"published_at" db:"published_at"`
-	ViewCount       int        `json:"view_count" db:"view_count"`
-	LikeCount       int        `json:"like_count" db:"like_count"`
-	DislikeCount    int        `json:"dislike_count" db:"dislike_count"`
-	CommentCount    int        `json:"comment_count" db:"comment_count"`
-	FeaturedImageID *string    `json:"featured_image_id" db:"featured_image_id"`
-	IsDeleted       bool       `json:"is_deleted" db:"is_deleted"`
+	ID              string     `json:"id" bson:"_id"`
+	Title           string     `json:"title" bson:"title"`
+	Content         string     `json:"content" bson:"content"`
+	AuthorID        string     `json:"author_id" bson:"author_id"`
+	Slug            string     `json:"slug" bson:"slug"`
+	Status          BlogStatus `json:"status" bson:"status"`
+	CreatedAt       time.Time  `json:"created_at" bson:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at" bson:"updated_at"`
+	PublishedAt     *time.Time `json:"published_at" bson:"published_at"`
+	ViewCount       int        `json:"view_count" bson:"view_count"`
+	LikeCount       int        `json:"like_count" bson:"like_count"`
+	DislikeCount    int        `json:"dislike_count" bson:"dislike_count"`
+	CommentCount    int        `json:"comment_count" bson:"comment_count"`
+	FeaturedImageID *string    `json:"featured_image_id" bson:"featured_image_id"`
+	IsDeleted       bool       `json:"is_deleted" bson:"is_deleted"`
 }
 
 // BlogStatus represents the status of a blog post

--- a/internal/infrastructure/repository/mongodb/blog_repo.go
+++ b/internal/infrastructure/repository/mongodb/blog_repo.go
@@ -97,15 +97,15 @@ func (r *BlogRepository) CreateBlog(ctx context.Context, blog *entity.Blog) erro
 	return nil
 }
 
-// GetBlogByID retrieves a single blog post by its unique ID.
-func (r *BlogRepository) GetBlogByID(ctx context.Context, blogID string) (*entity.Blog, error) {
+// GetBlogBySlug retrieves a single blog post by its unique slug.
+func (r *BlogRepository) GetBlogBySlug(ctx context.Context, slug string) (*entity.Blog, error) {
 	var blog entity.Blog
-	filter := bson.M{"id": blogID, "is_deleted": false}
+	filter := bson.M{"slug": slug, "is_deleted": false}
 
 	err := r.collection.FindOne(ctx, filter).Decode(&blog)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
-			return nil, fmt.Errorf("blog with ID %s not found or has been deleted: %w", blogID, err)
+			return nil, fmt.Errorf("blog with slug '%s' not found or has been deleted: %w", slug, err)
 		}
 		return nil, fmt.Errorf("failed to retrieve blog post: %w", err)
 	}
@@ -128,7 +128,7 @@ func (r *BlogRepository) GetBlogs(ctx context.Context, opts *contract.BlogFilter
 			bson.M{
 				"$lookup": bson.M{
 					"from":         "blog_tags",
-					"localField":   "id",
+					"localField":   "_id",
 					"foreignField": "blog_id",
 					"as":           "blogTags",
 				},
@@ -200,7 +200,7 @@ func (r *BlogRepository) GetBlogs(ctx context.Context, opts *contract.BlogFilter
 
 func (r *BlogRepository) UpdateBlog(ctx context.Context, blogID string, updates map[string]interface{}) error {
 	updates["updated_at"] = time.Now()
-	filter := bson.M{"id": blogID, "is_deleted": false}
+	filter := bson.M{"_id": blogID, "is_deleted": false}
 	update := bson.M{"$set": updates}
 
 	res, err := r.collection.UpdateOne(ctx, filter, update)
@@ -209,7 +209,7 @@ func (r *BlogRepository) UpdateBlog(ctx context.Context, blogID string, updates 
 	}
 	if res.ModifiedCount == 0 {
 		var blog entity.Blog
-		err := r.collection.FindOne(ctx, bson.M{"id": blogID}).Decode(&blog)
+		err := r.collection.FindOne(ctx, bson.M{"_id": blogID}).Decode(&blog)
 		if err != nil && errors.Is(err, mongo.ErrNoDocuments) {
 			return fmt.Errorf("blog post with ID %s not found", blogID)
 		}
@@ -220,7 +220,7 @@ func (r *BlogRepository) UpdateBlog(ctx context.Context, blogID string, updates 
 }
 
 func (r *BlogRepository) DeleteBlog(ctx context.Context, blogID string) error {
-	filter := bson.M{"id": blogID, "is_deleted": false}
+	filter := bson.M{"_id": blogID, "is_deleted": false}
 	update := bson.M{"$set": bson.M{"is_deleted": true, "updated_at": time.Now()}}
 
 	res, err := r.collection.UpdateOne(ctx, filter, update)
@@ -229,7 +229,7 @@ func (r *BlogRepository) DeleteBlog(ctx context.Context, blogID string) error {
 	}
 	if res.ModifiedCount == 0 {
 		var blog entity.Blog
-		err := r.collection.FindOne(ctx, bson.M{"id": blogID}).Decode(&blog)
+		err := r.collection.FindOne(ctx, bson.M{"_id": blogID}).Decode(&blog)
 		if err != nil && errors.Is(err, mongo.ErrNoDocuments) {
 			return fmt.Errorf("blog post with ID %s not found", blogID)
 		}
@@ -266,7 +266,7 @@ func (r *BlogRepository) SearchBlogs(ctx context.Context, query string, opts *co
 		{"$lookup": bson.M{
 			"from":         "users",
 			"localField":   "author_id",
-			"foreignField": "id",
+			"foreignField": "_id",
 			"as":           "authorDetails",
 		}},
 		{"$unwind": "$authorDetails"},
@@ -279,7 +279,7 @@ func (r *BlogRepository) SearchBlogs(ctx context.Context, query string, opts *co
 			bson.M{
 				"$lookup": bson.M{
 					"from":         "blog_tags",
-					"localField":   "id",
+					"localField":   "_id",
 					"foreignField": "blog_id",
 					"as":           "blogTags",
 				},
@@ -354,7 +354,7 @@ func (r *BlogRepository) SearchBlogs(ctx context.Context, query string, opts *co
 
 // IncrementViewCount increments the view count of a specific blog post.
 func (r *BlogRepository) IncrementViewCount(ctx context.Context, blogID string) error {
-	filter := bson.M{"id": blogID, "is_deleted": false}
+	filter := bson.M{"_id": blogID, "is_deleted": false}
 	update := bson.M{"$inc": bson.M{"view_count": 1}}
 
 	res, err := r.collection.UpdateOne(ctx, filter, update)
@@ -370,7 +370,7 @@ func (r *BlogRepository) IncrementViewCount(ctx context.Context, blogID string) 
 
 // IncrementLikeCount increments the like count of a specific blog post.
 func (r *BlogRepository) IncrementLikeCount(ctx context.Context, blogID string) error {
-	filter := bson.M{"id": blogID, "is_deleted": false}
+	filter := bson.M{"_id": blogID, "is_deleted": false}
 	update := bson.M{"$inc": bson.M{"like_count": 1}}
 
 	res, err := r.collection.UpdateOne(ctx, filter, update)
@@ -386,7 +386,7 @@ func (r *BlogRepository) IncrementLikeCount(ctx context.Context, blogID string) 
 
 // DecrementLikeCount decrements the like count of a specific blog post.
 func (r *BlogRepository) DecrementLikeCount(ctx context.Context, blogID string) error {
-	filter := bson.M{"id": blogID, "is_deleted": false}
+	filter := bson.M{"_id": blogID, "is_deleted": false}
 	update := bson.M{"$inc": bson.M{"like_count": -1}}
 
 	res, err := r.collection.UpdateOne(ctx, filter, update)
@@ -402,7 +402,7 @@ func (r *BlogRepository) DecrementLikeCount(ctx context.Context, blogID string) 
 
 // IncrementDislikeCount increments the dislike count of a specific blog post.
 func (r *BlogRepository) IncrementDislikeCount(ctx context.Context, blogID string) error {
-	filter := bson.M{"id": blogID, "is_deleted": false}
+	filter := bson.M{"_id": blogID, "is_deleted": false}
 	update := bson.M{"$inc": bson.M{"dislike_count": 1}}
 
 	res, err := r.collection.UpdateOne(ctx, filter, update)
@@ -418,7 +418,7 @@ func (r *BlogRepository) IncrementDislikeCount(ctx context.Context, blogID strin
 
 // DecrementDislikeCount decrements the dislike count of a specific blog post.
 func (r *BlogRepository) DecrementDislikeCount(ctx context.Context, blogID string) error {
-	filter := bson.M{"id": blogID, "is_deleted": false}
+	filter := bson.M{"_id": blogID, "is_deleted": false}
 	update := bson.M{"$inc": bson.M{"dislike_count": -1}}
 
 	res, err := r.collection.UpdateOne(ctx, filter, update)
@@ -434,7 +434,7 @@ func (r *BlogRepository) DecrementDislikeCount(ctx context.Context, blogID strin
 
 // IncrementCommentCount increments the comment count of a specific blog post.
 func (r *BlogRepository) IncrementCommentCount(ctx context.Context, blogID string) error {
-	filter := bson.M{"id": blogID, "is_deleted": false}
+	filter := bson.M{"_id": blogID, "is_deleted": false}
 	update := bson.M{"$inc": bson.M{"comment_count": 1}}
 
 	res, err := r.collection.UpdateOne(ctx, filter, update)
@@ -450,7 +450,7 @@ func (r *BlogRepository) IncrementCommentCount(ctx context.Context, blogID strin
 
 // DecrementCommentCount decrements the comment count of a specific blog post.
 func (r *BlogRepository) DecrementCommentCount(ctx context.Context, blogID string) error {
-	filter := bson.M{"id": blogID, "is_deleted": false}
+	filter := bson.M{"_id": blogID, "is_deleted": false}
 	update := bson.M{"$inc": bson.M{"comment_count": -1}}
 
 	res, err := r.collection.UpdateOne(ctx, filter, update)
@@ -467,7 +467,7 @@ func (r *BlogRepository) DecrementCommentCount(ctx context.Context, blogID strin
 // GetBlogCounts returns the current counts for a blog post.
 func (r *BlogRepository) GetBlogCounts(ctx context.Context, blogID string) (viewCount, likeCount, dislikeCount, commentCount int, err error) {
 	var blog entity.Blog
-	filter := bson.M{"id": blogID, "is_deleted": false}
+	filter := bson.M{"_id": blogID, "is_deleted": false}
 	err = r.collection.FindOne(ctx, filter).Decode(&blog)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
@@ -479,13 +479,13 @@ func (r *BlogRepository) GetBlogCounts(ctx context.Context, blogID string) (view
 }
 
 // AddTagsToBlog associates one or more tags with a blog post.
-func (r *BlogRepository) AddTagsToBlog(ctx context.Context, blogID string, tagIDs []string) error {
+func (r *BlogRepository) AddTagsToBlog(ctx context.Context, blogSlug string, tagIDs []string) error {
 	if len(tagIDs) == 0 {
 		return nil
 	}
 
-	// Check if the blog exists and is not deleted
-	_, err := r.GetBlogByID(ctx, blogID)
+	// Check if the blog exists and is not deleted using its slug
+	blog, err := r.GetBlogBySlug(ctx, blogSlug)
 	if err != nil {
 		return fmt.Errorf("blog not found: %w", err)
 	}
@@ -494,7 +494,7 @@ func (r *BlogRepository) AddTagsToBlog(ctx context.Context, blogID string, tagID
 	var blogTags []interface{}
 	for _, tagIDStr := range tagIDs {
 		blogTag := entity.BlogTag{
-			BlogID: blogID,
+			BlogID: blog.ID,
 			TagID:  tagIDStr,
 		}
 		blogTags = append(blogTags, blogTag)
@@ -508,7 +508,7 @@ func (r *BlogRepository) AddTagsToBlog(ctx context.Context, blogID string, tagID
 		if writeException, ok := err.(mongo.BulkWriteException); ok {
 			for _, e := range writeException.WriteErrors {
 				if e.Code == 11000 {
-					fmt.Printf("Warning: Duplicate blog-tag association for blog %s and tag with index %d. Error: %v\n", blogID, e.Index, e)
+					fmt.Printf("Warning: Duplicate blog-tag association for blog %s and tag with index %d. Error: %v\n", blog.ID, e.Index, e)
 				} else {
 					return fmt.Errorf("failed to add tags: %w", err)
 				}
@@ -521,20 +521,20 @@ func (r *BlogRepository) AddTagsToBlog(ctx context.Context, blogID string, tagID
 }
 
 // RemoveTagsFromBlog disassociates one or more tags from a blog post.
-func (r *BlogRepository) RemoveTagsFromBlog(ctx context.Context, blogID string, tagIDs []string) error {
+func (r *BlogRepository) RemoveTagsFromBlog(ctx context.Context, blogSlug string, tagIDs []string) error {
 	if len(tagIDs) == 0 {
 		return nil
 	}
 
-	// Check if the blog exists and is not deleted
-	_, err := r.GetBlogByID(ctx, blogID)
+	// Check if the blog exists and is not deleted using its slug
+	blog, err := r.GetBlogBySlug(ctx, blogSlug)
 	if err != nil {
 		return fmt.Errorf("blog not found: %w", err)
 	}
 
 	// Prepare filter for deletion
 	filter := bson.M{
-		"blog_id": blogID,
+		"blog_id": blog.ID,
 		"tag_id":  bson.M{"$in": tagIDs},
 	}
 


### PR DESCRIPTION
Updated the blog repository methods to rely on **slug** for lookups instead of numeric IDs.

## Why?
- Enhances URL friendliness and readability.
- Standardizes entity identification across the application.
- Reduces reliance on numerical primary keys, improving decoupling and flexibility.

## Changes
- Modified `GetBlogByID` (or similar method) to `GetBlogBySlug` internally.
- Updated all method signatures, internal calls, and tests to operate based on slug.
- Ensured backward compatibility is maintained (if applicable).